### PR TITLE
Add color preference management and settings panel

### DIFF
--- a/src/lib/components/map/MapContainer.svelte
+++ b/src/lib/components/map/MapContainer.svelte
@@ -46,6 +46,7 @@
   import {
     addTrackingItem,
     toggleTrackingItem,
+    loadColorPreference,
   } from "$lib/stores/tracking-store.svelte";
   import { getLatestGistRaw } from "$lib/services/gist-service";
   import { fetchResource, fetchEnemy } from "$lib/services/api-service";
@@ -547,12 +548,13 @@
         () => {
           playerInfoPromise.then((results) => {
             playerIds.forEach((id, i) => {
+              const savedColor = loadColorPreference('player', id);
               addTrackingItem({
                 id: -1,
                 entityId: id,
                 type: "player",
                 text: `Player: ${results[i].username}`,
-                color: "#00ff00",
+                color: savedColor || "#00ff00",
                 visible: true,
               });
             });
@@ -662,7 +664,7 @@
           entityId,
           type: "player",
           text: `Player: ${playerInfo.username}`,
-          color,
+          color: loadColorPreference('player', entityId) || color,
           visible: true,
         });
       },
@@ -773,7 +775,7 @@
     trackedResourceIds.add(resourceId);
     updateResourceIdParam(trackedResourceIds);
 
-    const color = tierColors[tier] || "#3388ff";
+    const color = loadColorPreference('resource', resourceId) || tierColors[tier] || "#3388ff";
     const canvasLayer = new ResourceCanvasLayer({ color, name, tier, id: resourceId });
     resourceLayers[resourceId] = canvasLayer;
     canvasLayer.addTo(map);
@@ -821,7 +823,7 @@
     trackedEnemyIds.add(enemyId);
     updateEnemyIdParam(trackedEnemyIds);
 
-    const color =
+    const color = loadColorPreference('resource', enemyId) ||
       creatureIndex[enemyId]?.color || tierColors[tier] || "#3388ff";
     const canvasLayer = new ResourceCanvasLayer({ color, name, tier, id: enemyId });
     resourceLayers[enemyId] = canvasLayer;
@@ -896,7 +898,7 @@
     let trackingList: { text: string; color: string; id: number }[] = [];
 
     for (const id of resourceIds) {
-      let color =
+      let color = loadColorPreference('resource', id) ||
         resourceIndexOverride[id]?.color ||
         tierColors[resourceIndexOverride[id]?.tier] ||
         resourceIndex[id]?.color ||
@@ -909,7 +911,7 @@
       resourceLayers[id].addTo(map);
     }
     for (const id of enemyIds) {
-      let color =
+      let color = loadColorPreference('resource', id) ||
         creatureIndex[id]?.color ||
         tierColors[creatureIndex[id]?.tier] ||
         "#3388ff";
@@ -922,7 +924,7 @@
 
     for (const rId of regionIds) {
       for (const resId of resourceIds) {
-        let color =
+        let color = loadColorPreference('resource', resId) ||
           resourceIndexOverride[resId]?.color ||
           tierColors[resourceIndexOverride[resId]?.tier] ||
           resourceIndex[resId]?.color ||
@@ -941,7 +943,7 @@
         });
       }
       for (const eId of enemyIds) {
-        let color =
+        let color = loadColorPreference('resource', eId) ||
           creatureIndex[eId]?.color ||
           tierColors[creatureIndex[eId]?.tier] ||
           "#3388ff";
@@ -964,7 +966,7 @@
         id: item.id,
         type: "resource",
         text: item.text,
-        color: item.color,
+        color: noColors ? '#3388ff' : (loadColorPreference('resource', item.id) || item.color),
         visible: true,
       });
     }

--- a/src/lib/components/map/MapContainer.svelte
+++ b/src/lib/components/map/MapContainer.svelte
@@ -823,7 +823,7 @@
     trackedEnemyIds.add(enemyId);
     updateEnemyIdParam(trackedEnemyIds);
 
-    const color = loadColorPreference('resource', enemyId) ||
+    const color = loadColorPreference('enemy', enemyId) ||
       creatureIndex[enemyId]?.color || tierColors[tier] || "#3388ff";
     const canvasLayer = new ResourceCanvasLayer({ color, name, tier, id: enemyId });
     resourceLayers[enemyId] = canvasLayer;
@@ -831,7 +831,7 @@
 
     addTrackingItem({
       id: enemyId,
-      type: "resource",
+      type: "enemy",
       text: `Tracking: ${name}, Tier ${tier}`,
       color,
       visible: true,
@@ -895,7 +895,7 @@
       fillColor: string;
       resource: number;
     }[] = [];
-    let trackingList: { text: string; color: string; id: number }[] = [];
+    let trackingList: { text: string; color: string; id: number; type: 'resource' | 'enemy' }[] = [];
 
     for (const id of resourceIds) {
       let color = loadColorPreference('resource', id) ||
@@ -911,7 +911,7 @@
       resourceLayers[id].addTo(map);
     }
     for (const id of enemyIds) {
-      let color = loadColorPreference('resource', id) ||
+      let color = loadColorPreference('enemy', id) ||
         creatureIndex[id]?.color ||
         tierColors[creatureIndex[id]?.tier] ||
         "#3388ff";
@@ -940,10 +940,11 @@
           text: "Tracking: " + name + ", Tier " + tier,
           color,
           id: resId,
+          type: 'resource',
         });
       }
       for (const eId of enemyIds) {
-        let color = loadColorPreference('resource', eId) ||
+        let color = loadColorPreference('enemy', eId) ||
           creatureIndex[eId]?.color ||
           tierColors[creatureIndex[eId]?.tier] ||
           "#3388ff";
@@ -956,6 +957,7 @@
           text: "Tracking: " + name + ", Tier " + tier,
           color,
           id: eId,
+          type: 'enemy',
         });
       }
     }
@@ -964,9 +966,9 @@
     for (const item of trackingList) {
       addTrackingItem({
         id: item.id,
-        type: "resource",
+        type: item.type,
         text: item.text,
-        color: noColors ? '#3388ff' : (loadColorPreference('resource', item.id) || item.color),
+        color: noColors ? '#3388ff' : (loadColorPreference(item.type, item.id) || item.color),
         visible: true,
       });
     }

--- a/src/lib/components/settings/SettingsPanel.svelte
+++ b/src/lib/components/settings/SettingsPanel.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import { Palette, RotateCcw, X } from '@lucide/svelte';
+	import { getAllColorPreferences, saveColorPreference, removeColorPreference, clearAllColorPreferences, clearTracking } from '$lib/stores/tracking-store.svelte';
+	import { selectAllRegions } from '$lib/stores/region-store.svelte';
+	import { resetView } from '$lib/stores/map-store';
+	import { resourceIndex, resourceIndexOverride, creatureIndex } from '$lib/data/resource-index';
+
+	let colorEntries = $state(loadEntries());
+
+	function loadEntries() {
+		const store = getAllColorPreferences();
+		return Object.entries(store).map(([key, color]) => {
+			const [type, id] = key.split(':') as ['resource' | 'player', string];
+			let name = `${type === 'player' ? 'Player' : 'Resource'} ${id}`;
+			if (type === 'resource') {
+				name = resourceIndexOverride[id]?.name || resourceIndex[id]?.name || creatureIndex[id]?.name || name;
+			}
+			return { key, type, id, name, color };
+		});
+	}
+
+	function refresh() {
+		colorEntries = loadEntries();
+	}
+
+	function handleColorChange(type: 'resource' | 'player', id: string, color: string) {
+		saveColorPreference(type, id, color);
+		refresh();
+	}
+
+	function handleRemove(type: 'resource' | 'player', id: string) {
+		removeColorPreference(type, id);
+		refresh();
+	}
+
+	function handleClearColors() {
+		clearAllColorPreferences();
+		refresh();
+	}
+
+	function handleResetEverything() {
+		clearAllColorPreferences();
+		clearTracking();
+		selectAllRegions();
+		resetView();
+		localStorage.setItem('activeLayers', JSON.stringify(["Events", "Wonders", "Temples", "Ruined Cities"]));
+		location.reload();
+	}
+
+	let colorInputs: Record<string, HTMLInputElement> = {};
+	let confirmingReset = $state(false);
+</script>
+
+<div class="space-y-5">
+	<!-- Saved Colors -->
+	<section>
+		<div class="flex items-center gap-2 px-1 mb-2.5">
+			<Palette size={14} class="text-gray-400" />
+			<h3 class="text-[11px] font-semibold text-gray-300 uppercase tracking-wider flex-1">Saved Colors</h3>
+			{#if colorEntries.length > 0}
+				<button
+					type="button"
+					onclick={handleClearColors}
+					class="text-[10px] text-gray-500 hover:text-red-400 transition-colors cursor-pointer px-1.5 py-0.5 rounded hover:bg-white/5"
+				>
+					Clear all
+				</button>
+			{/if}
+		</div>
+
+		{#if colorEntries.length > 0}
+			<div class="space-y-1">
+				{#each colorEntries as entry (entry.key)}
+					<div
+						class="group flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs border border-white/5 hover:border-white/10 transition-colors"
+						style:background-color={entry.color + '18'}
+					>
+						<button
+							type="button"
+							class="w-4 h-4 rounded-full cursor-pointer ring-1 ring-white/20 hover:ring-white/50 hover:scale-110 transition-all shrink-0 shadow-sm"
+							style:background-color={entry.color}
+							onclick={() => colorInputs[entry.key]?.click()}
+							aria-label="Change color"
+						></button>
+						<input
+							bind:this={colorInputs[entry.key]}
+							type="color"
+							value={entry.color}
+							class="sr-only"
+							oninput={(e) => handleColorChange(entry.type, entry.id, e.currentTarget.value)}
+						/>
+						<div class="flex-1 min-w-0">
+							<span class="text-gray-200 block truncate">{entry.name}</span>
+						</div>
+						<span class="text-[10px] text-gray-500 bg-white/5 px-1.5 py-0.5 rounded">{entry.type}</span>
+						<button
+							onclick={() => handleRemove(entry.type, entry.id)}
+							class="cursor-pointer text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity hover:text-red-400"
+							aria-label="Remove color"
+						>
+							<X size={14} />
+						</button>
+					</div>
+				{/each}
+			</div>
+		{:else}
+			<div class="flex flex-col items-center py-4 text-gray-500">
+				<Palette size={20} class="mb-1.5 opacity-40" />
+				<p class="text-xs">No saved colors</p>
+			</div>
+		{/if}
+	</section>
+
+	<!-- Divider -->
+	<div class="border-t border-white/5"></div>
+
+	<!-- Reset Everything -->
+	<div class="px-1 pb-1">
+		{#if !confirmingReset}
+			<button
+				type="button"
+				onclick={() => confirmingReset = true}
+				class="w-full flex items-center justify-center gap-2 text-xs rounded-lg px-3 py-2.5 text-red-400/70 hover:text-red-400 border border-red-400/10 hover:border-red-400/25 hover:bg-red-400/5 transition-colors cursor-pointer"
+			>
+				<RotateCcw size={13} />
+				Reset everything to defaults
+			</button>
+		{:else}
+			<div class="rounded-lg border border-red-400/20 bg-red-400/5 px-3 py-2.5 space-y-2">
+				<p class="text-[11px] text-red-300/80 text-center">This will clear all saved colors, tracking, regions, layers and map position.</p>
+				<div class="flex gap-2">
+					<button
+						type="button"
+						onclick={() => confirmingReset = false}
+						class="flex-1 text-xs rounded-md px-3 py-1.5 text-gray-400 hover:text-gray-200 border border-white/10 hover:bg-white/5 transition-colors cursor-pointer"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onclick={handleResetEverything}
+						class="flex-1 text-xs rounded-md px-3 py-1.5 text-red-400 border border-red-400/25 hover:bg-red-400/10 transition-colors cursor-pointer"
+					>
+						Confirm
+					</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/settings/SettingsPanel.svelte
+++ b/src/lib/components/settings/SettingsPanel.svelte
@@ -10,10 +10,14 @@
 	function loadEntries() {
 		const store = getAllColorPreferences();
 		return Object.entries(store).map(([key, color]) => {
-			const [type, id] = key.split(':') as ['resource' | 'player', string];
-			let name = `${type === 'player' ? 'Player' : 'Resource'} ${id}`;
-			if (type === 'resource') {
-				name = resourceIndexOverride[id]?.name || resourceIndex[id]?.name || creatureIndex[id]?.name || name;
+			const [type, id] = key.split(':') as ['resource' | 'enemy' | 'player', string];
+			let name: string;
+			if (type === 'enemy') {
+				name = creatureIndex[id]?.name || `Enemy ${id}`;
+			} else if (type === 'resource') {
+				name = resourceIndexOverride[id]?.name || resourceIndex[id]?.name || `Resource ${id}`;
+			} else {
+				name = `Player ${id}`;
 			}
 			return { key, type, id, name, color };
 		});
@@ -23,12 +27,12 @@
 		colorEntries = loadEntries();
 	}
 
-	function handleColorChange(type: 'resource' | 'player', id: string, color: string) {
+	function handleColorChange(type: 'resource' | 'enemy' | 'player', id: string, color: string) {
 		saveColorPreference(type, id, color);
 		refresh();
 	}
 
-	function handleRemove(type: 'resource' | 'player', id: string) {
+	function handleRemove(type: 'resource' | 'enemy' | 'player', id: string) {
 		removeColorPreference(type, id);
 		refresh();
 	}

--- a/src/lib/components/sidebar/Sidebar.svelte
+++ b/src/lib/components/sidebar/Sidebar.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import type L from 'leaflet';
 	import { fly, fade } from 'svelte/transition';
-	import { Layers, MapPinned, Crosshair, Globe, XIcon } from '@lucide/svelte';
+	import { Layers, MapPinned, Crosshair, Globe, XIcon, Settings } from '@lucide/svelte';
 	import { getSidebarState, toggleSidebarTab, closeSidebar, type SidebarTab } from '$lib/stores/sidebar-store.svelte';
 	import { getTrackingState } from '$lib/stores/tracking-store.svelte';
 	import LayersPanel from '$lib/components/layers/LayersPanel.svelte';
 	import LayerPanel from '$lib/components/layers/LayerPanel.svelte';
 	import TrackingPanel from '$lib/components/tracking/TrackingPanel.svelte';
 	import RegionSelector from '$lib/components/regions/RegionSelector.svelte';
+	import SettingsPanel from '$lib/components/settings/SettingsPanel.svelte';
 
 	let {
 		genericToggle,
@@ -40,7 +41,8 @@
 		{ id: 'layers', label: 'Layers', icon: Layers },
 		{ id: 'features', label: 'Features', icon: MapPinned },
 		{ id: 'tracking', label: 'Tracking', icon: Crosshair },
-		{ id: 'regions', label: 'Regions', icon: Globe }
+		{ id: 'regions', label: 'Regions', icon: Globe },
+		{ id: 'settings', label: 'Settings', icon: Settings }
 	];
 
 	function tabLabel(id: SidebarTab): string {
@@ -74,7 +76,8 @@
 	{#if sidebar.isExpanded}
 		<div
 			transition:fly={{ x: -20, duration: 200 }}
-			class="ml-1 w-64 min-w-64 max-w-64 shrink-0 max-h-[calc(100dvh-8rem)] overflow-y-auto overflow-x-hidden rounded-lg bg-[#1e2433]/95 border border-white/10 backdrop-blur-sm shadow-lg"
+			class="ml-1 shrink-0 max-h-[calc(100dvh-8rem)] overflow-y-auto overflow-x-hidden rounded-lg bg-[#1e2433]/95 border border-white/10 backdrop-blur-sm shadow-lg transition-[width] duration-200
+				{sidebar.activeTab === 'settings' ? 'w-80 min-w-80 max-w-80' : 'w-64 min-w-64 max-w-64'}"
 		>
 			<div class="flex items-center justify-between px-3 py-2 border-b border-white/10">
 				<h2 class="text-xs font-semibold text-gray-200 uppercase tracking-wider">
@@ -104,6 +107,8 @@
 					/>
 				{:else if sidebar.activeTab === 'regions'}
 					<RegionSelector {onRegionsChange} />
+				{:else if sidebar.activeTab === 'settings'}
+					<SettingsPanel />
 				{/if}
 			</div>
 		</div>
@@ -159,6 +164,8 @@
 					/>
 				{:else if sidebar.activeTab === 'regions'}
 					<RegionSelector {onRegionsChange} />
+				{:else if sidebar.activeTab === 'settings'}
+					<SettingsPanel />
 				{/if}
 			</div>
 		</div>

--- a/src/lib/stores/sidebar-store.svelte.ts
+++ b/src/lib/stores/sidebar-store.svelte.ts
@@ -1,4 +1,4 @@
-export type SidebarTab = 'layers' | 'features' | 'tracking' | 'regions';
+export type SidebarTab = 'layers' | 'features' | 'tracking' | 'regions' | 'settings';
 
 let activeTab = $state<SidebarTab | null>(null);
 

--- a/src/lib/stores/tracking-store.svelte.ts
+++ b/src/lib/stores/tracking-store.svelte.ts
@@ -1,12 +1,31 @@
 import type { TrackingItem } from '$lib/types/geojson';
 
 const STORAGE_KEY = 'trackingColors';
+let cachedStore: Record<string, string> | null = null;
+
+if (typeof window !== 'undefined') {
+	window.addEventListener('storage', (e) => {
+		if (e.key === STORAGE_KEY) {
+			cachedStore = null;
+		}
+	});
+}
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+function isValidColor(color: string): boolean {
+	return HEX_COLOR_RE.test(color);
+}
 
 function getColorStore(): Record<string, string> {
+	if (cachedStore !== null) return cachedStore;
 	try {
-		return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+		const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+		cachedStore = parsed;
+		return parsed;
 	} catch {
-		return {};
+		cachedStore = {};
+		return cachedStore;
 	}
 }
 
@@ -17,27 +36,44 @@ function colorKey(type: 'resource' | 'enemy' | 'player' | undefined, id: number 
 }
 
 export function saveColorPreference(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string, color: string): void {
+	if (!isValidColor(color)) return;
 	const store = getColorStore();
 	store[colorKey(type, id)] = color;
-	localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+	} catch (e) { console.warn('Failed to save color preference:', e); }
+	cachedStore = store;
 }
 
 export function loadColorPreference(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string): string | undefined {
-	return getColorStore()[colorKey(type, id)];
+	const color = getColorStore()[colorKey(type, id)];
+	if (color !== undefined && !isValidColor(color)) return undefined;
+	return color;
 }
 
 export function removeColorPreference(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string): void {
 	const store = getColorStore();
 	delete store[colorKey(type, id)];
-	localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+	} catch (e) { console.warn('Failed to remove color preference:', e); }
+	cachedStore = store;
 }
 
 export function getAllColorPreferences(): Record<string, string> {
-	return getColorStore();
+	const store = getColorStore();
+	const filtered: Record<string, string> = {};
+	for (const [key, color] of Object.entries(store)) {
+		if (isValidColor(color)) filtered[key] = color;
+	}
+	return filtered;
 }
 
 export function clearAllColorPreferences(): void {
-	localStorage.removeItem(STORAGE_KEY);
+	try {
+		localStorage.removeItem(STORAGE_KEY);
+	} catch (e) { console.warn('Failed to clear color preferences:', e); }
+	cachedStore = null;
 }
 
 let items = $state<TrackingItem[]>([]);
@@ -77,12 +113,14 @@ export function removeTrackingItemByEntityId(entityId: string): void {
 }
 
 export function updateTrackingItemColor(id: number, color: string): void {
+	if (!isValidColor(color)) return;
 	const item = items.find((i) => i.id === id);
 	if (item) saveColorPreference(item.type, id, color);
 	items = items.map((i) => (i.id === id ? { ...i, color } : i));
 }
 
 export function updateTrackingItemColorByEntityId(entityId: string, color: string): void {
+	if (!isValidColor(color)) return;
 	saveColorPreference('player', entityId, color);
 	items = items.map((i) => (i.entityId === entityId ? { ...i, color } : i));
 }

--- a/src/lib/stores/tracking-store.svelte.ts
+++ b/src/lib/stores/tracking-store.svelte.ts
@@ -1,5 +1,43 @@
 import type { TrackingItem } from '$lib/types/geojson';
 
+const STORAGE_KEY = 'trackingColors';
+
+function getColorStore(): Record<string, string> {
+	try {
+		return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+	} catch {
+		return {};
+	}
+}
+
+function colorKey(type: 'resource' | 'player' | undefined, id: number | string): string {
+	return type === 'player' ? `player:${id}` : `resource:${id}`;
+}
+
+export function saveColorPreference(type: 'resource' | 'player' | undefined, id: number | string, color: string): void {
+	const store = getColorStore();
+	store[colorKey(type, id)] = color;
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function loadColorPreference(type: 'resource' | 'player' | undefined, id: number | string): string | undefined {
+	return getColorStore()[colorKey(type, id)];
+}
+
+export function removeColorPreference(type: 'resource' | 'player' | undefined, id: number | string): void {
+	const store = getColorStore();
+	delete store[colorKey(type, id)];
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getAllColorPreferences(): Record<string, string> {
+	return getColorStore();
+}
+
+export function clearAllColorPreferences(): void {
+	localStorage.removeItem(STORAGE_KEY);
+}
+
 let items = $state<TrackingItem[]>([]);
 
 export function getTrackingState() {
@@ -37,10 +75,13 @@ export function removeTrackingItemByEntityId(entityId: string): void {
 }
 
 export function updateTrackingItemColor(id: number, color: string): void {
+	const item = items.find((i) => i.id === id);
+	if (item) saveColorPreference(item.type, id, color);
 	items = items.map((i) => (i.id === id ? { ...i, color } : i));
 }
 
 export function updateTrackingItemColorByEntityId(entityId: string, color: string): void {
+	saveColorPreference('player', entityId, color);
 	items = items.map((i) => (i.entityId === entityId ? { ...i, color } : i));
 }
 

--- a/src/lib/stores/tracking-store.svelte.ts
+++ b/src/lib/stores/tracking-store.svelte.ts
@@ -10,21 +10,23 @@ function getColorStore(): Record<string, string> {
 	}
 }
 
-function colorKey(type: 'resource' | 'player' | undefined, id: number | string): string {
-	return type === 'player' ? `player:${id}` : `resource:${id}`;
+function colorKey(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string): string {
+	if (type === 'player') return `player:${id}`;
+	if (type === 'enemy') return `enemy:${id}`;
+	return `resource:${id}`;
 }
 
-export function saveColorPreference(type: 'resource' | 'player' | undefined, id: number | string, color: string): void {
+export function saveColorPreference(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string, color: string): void {
 	const store = getColorStore();
 	store[colorKey(type, id)] = color;
 	localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
 }
 
-export function loadColorPreference(type: 'resource' | 'player' | undefined, id: number | string): string | undefined {
+export function loadColorPreference(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string): string | undefined {
 	return getColorStore()[colorKey(type, id)];
 }
 
-export function removeColorPreference(type: 'resource' | 'player' | undefined, id: number | string): void {
+export function removeColorPreference(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string): void {
 	const store = getColorStore();
 	delete store[colorKey(type, id)];
 	localStorage.setItem(STORAGE_KEY, JSON.stringify(store));

--- a/src/lib/types/geojson.ts
+++ b/src/lib/types/geojson.ts
@@ -38,7 +38,7 @@ export interface BitcraftFeatureProperties {
 export interface TrackingItem {
 	id: number;
 	entityId?: string;
-	type?: 'resource' | 'player';
+	type?: 'resource' | 'enemy' | 'player';
 	text: string;
 	color: string;
 	visible: boolean;


### PR DESCRIPTION
- Introduced a new SettingsPanel component for managing saved color preferences for players and resources and provide a place to do a full state clear in userland.
- Implemented functions to save, load, remove, and clear color preferences in the tracking store.
- Updated MapContainer to utilize color preferences when adding tracking items and resources.