### PR TITLE
Refactor color sync to use store-based handler and add display name persistence

### DIFF
--- a/src/lib/components/map/MapContainer.svelte
+++ b/src/lib/components/map/MapContainer.svelte
@@ -47,6 +47,7 @@
     addTrackingItem,
     toggleTrackingItem,
     loadColorPreference,
+    registerColorSyncHandler,
   } from "$lib/stores/tracking-store.svelte";
   import { getLatestGistRaw } from "$lib/services/gist-service";
   import { fetchResource, fetchEnemy } from "$lib/services/api-service";
@@ -535,6 +536,7 @@
                 destination_z: info.locationZ,
               },
               urlParams.followPlayer,
+              loadColorPreference('player', playerIds[i]) || "#00ff00",
             );
           }
         });
@@ -543,7 +545,7 @@
       const ws = connectWebSocket(
         playerIds,
         (state: PlayerState) => {
-          updatePlayerMarker(state, urlParams.followPlayer);
+          updatePlayerMarker(state, urlParams.followPlayer, loadColorPreference('player', state.entity_id) || "#00ff00");
         },
         () => {
           playerInfoPromise.then((results) => {
@@ -584,7 +586,26 @@
       handleResourceEvent(event, resourceUpdateCtx);
     });
 
+    const unregisterColorSync = registerColorSyncHandler((type, id, color) => {
+      if (type === 'player') {
+        const marker = playerStore.get(id as string);
+        if (marker) {
+          const el = marker.getElement();
+          if (el) {
+            const dot = el.querySelector(".player-dot") as HTMLElement;
+            const pulse = el.querySelector(".player-pulse") as HTMLElement;
+            if (dot) dot.style.backgroundColor = color;
+            if (pulse) pulse.style.borderColor = color;
+          }
+        }
+      } else {
+        const layer = resourceLayers[id as number];
+        if (layer) layer.setColor(color);
+      }
+    });
+
     return () => {
+      unregisterColorSync();
       for (const ws of playerWebSockets.values()) {
         ws.close();
       }
@@ -633,9 +654,10 @@
     playerUsernames.set(entityId, username);
     updatePlayerIdParam(trackedPlayerIds);
 
-    const color =
+    const paletteColor =
       playerColorPalette[playerColorIndex % playerColorPalette.length];
     playerColorIndex++;
+    const color = loadColorPreference('player', entityId) || paletteColor;
 
     // Fetch initial location from API
     const playerInfo = await lookupPlayer(entityId);
@@ -656,7 +678,7 @@
     const ws = connectWebSocket(
       [entityId],
       (state: PlayerState) => {
-        updatePlayerMarker(state, false, color);
+        updatePlayerMarker(state, false, loadColorPreference('player', entityId) || color);
       },
       () => {
         addTrackingItem({
@@ -664,7 +686,7 @@
           entityId,
           type: "player",
           text: `Player: ${playerInfo.username}`,
-          color: loadColorPreference('player', entityId) || color,
+          color,
           visible: true,
         });
       },
@@ -1036,26 +1058,6 @@
     unsubscribeResource(id);
   }
 
-  function handleColorChangeResource(id: number, color: string): void {
-    const layer = resourceLayers[id];
-    if (layer) {
-      layer.setColor(color);
-    }
-  }
-
-  function handleColorChangePlayer(entityId: string, color: string): void {
-    const marker = playerStore.get(entityId);
-    if (marker) {
-      const el = marker.getElement();
-      if (el) {
-        const dot = el.querySelector(".player-dot") as HTMLElement;
-        const pulse = el.querySelector(".player-pulse") as HTMLElement;
-        if (dot) dot.style.backgroundColor = color;
-        if (pulse) pulse.style.borderColor = color;
-      }
-    }
-  }
-
   function handleRemovePlayer(entityId: string): void {
     // Remove markers
     const marker = playerStore.get(entityId);
@@ -1172,8 +1174,6 @@
       onTogglePlayer={handleTogglePlayerVisibility}
       onRemoveResource={handleRemoveResource}
       onRemovePlayer={handleRemovePlayer}
-      onColorChangeResource={handleColorChangeResource}
-      onColorChangePlayer={handleColorChangePlayer}
       onRegionsChange={handleRegionsChange}
     />
     <DetailPanel

--- a/src/lib/components/settings/SettingsPanel.svelte
+++ b/src/lib/components/settings/SettingsPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Palette, RotateCcw, X } from '@lucide/svelte';
-	import { getAllColorPreferences, saveColorPreference, removeColorPreference, clearAllColorPreferences, clearTracking } from '$lib/stores/tracking-store.svelte';
+	import { getAllColorPreferences, getAllDisplayNames, removeColorPreference, clearAllColorPreferences, clearTracking, updateTrackingItemColor, updateTrackingItemColorByEntityId } from '$lib/stores/tracking-store.svelte';
 	import { selectAllRegions } from '$lib/stores/region-store.svelte';
 	import { resetView } from '$lib/stores/map-store';
 	import { resourceIndex, resourceIndexOverride, creatureIndex } from '$lib/data/resource-index';
@@ -9,10 +9,14 @@
 
 	function loadEntries() {
 		const store = getAllColorPreferences();
+		const names = getAllDisplayNames();
 		return Object.entries(store).map(([key, color]) => {
 			const [type, id] = key.split(':') as ['resource' | 'enemy' | 'player', string];
+			const savedName = names[key];
 			let name: string;
-			if (type === 'enemy') {
+			if (savedName) {
+				name = savedName;
+			} else if (type === 'enemy') {
 				name = creatureIndex[id]?.name || `Enemy ${id}`;
 			} else if (type === 'resource') {
 				name = resourceIndexOverride[id]?.name || resourceIndex[id]?.name || `Resource ${id}`;
@@ -28,7 +32,11 @@
 	}
 
 	function handleColorChange(type: 'resource' | 'enemy' | 'player', id: string, color: string) {
-		saveColorPreference(type, id, color);
+		if (type === 'player') {
+			updateTrackingItemColorByEntityId(id, color);
+		} else {
+			updateTrackingItemColor(Number(id), color);
+		}
 		refresh();
 	}
 
@@ -51,7 +59,6 @@
 		location.reload();
 	}
 
-	let colorInputs: Record<string, HTMLInputElement> = {};
 	let confirmingReset = $state(false);
 </script>
 
@@ -79,20 +86,17 @@
 						class="group flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs border border-white/5 hover:border-white/10 transition-colors"
 						style:background-color={entry.color + '18'}
 					>
-						<button
-							type="button"
+						<label
 							class="w-4 h-4 rounded-full cursor-pointer ring-1 ring-white/20 hover:ring-white/50 hover:scale-110 transition-all shrink-0 shadow-sm"
 							style:background-color={entry.color}
-							onclick={() => colorInputs[entry.key]?.click()}
-							aria-label="Change color"
-						></button>
-						<input
-							bind:this={colorInputs[entry.key]}
-							type="color"
-							value={entry.color}
-							class="sr-only"
-							oninput={(e) => handleColorChange(entry.type, entry.id, e.currentTarget.value)}
-						/>
+						>
+							<input
+								type="color"
+								value={entry.color}
+								class="sr-only"
+								oninput={(e) => handleColorChange(entry.type, entry.id, e.currentTarget.value)}
+							/>
+						</label>
 						<div class="flex-1 min-w-0">
 							<span class="text-gray-200 block truncate">{entry.name}</span>
 						</div>

--- a/src/lib/components/sidebar/Sidebar.svelte
+++ b/src/lib/components/sidebar/Sidebar.svelte
@@ -18,8 +18,6 @@
 		onTogglePlayer,
 		onRemoveResource,
 		onRemovePlayer,
-		onColorChangeResource,
-		onColorChangePlayer,
 		onRegionsChange
 	}: {
 		genericToggle: Record<string, L.LayerGroup>;
@@ -29,8 +27,6 @@
 		onTogglePlayer: (entityId: string) => void;
 		onRemoveResource: (id: number) => void;
 		onRemovePlayer: (entityId: string) => void;
-		onColorChangeResource: (id: number, color: string) => void;
-		onColorChangePlayer: (entityId: string, color: string) => void;
 		onRegionsChange: () => void;
 	} = $props();
 
@@ -102,8 +98,6 @@
 						{onTogglePlayer}
 						{onRemoveResource}
 						{onRemovePlayer}
-						{onColorChangeResource}
-						{onColorChangePlayer}
 					/>
 				{:else if sidebar.activeTab === 'regions'}
 					<RegionSelector {onRegionsChange} />
@@ -159,8 +153,6 @@
 						{onTogglePlayer}
 						{onRemoveResource}
 						{onRemovePlayer}
-						{onColorChangeResource}
-						{onColorChangePlayer}
 					/>
 				{:else if sidebar.activeTab === 'regions'}
 					<RegionSelector {onRegionsChange} />

--- a/src/lib/components/tracking/TrackingPanel.svelte
+++ b/src/lib/components/tracking/TrackingPanel.svelte
@@ -7,15 +7,11 @@
 		onTogglePlayer,
 		onRemoveResource,
 		onRemovePlayer,
-		onColorChangeResource,
-		onColorChangePlayer
 	}: {
 		onToggleResource: (id: number) => void;
 		onTogglePlayer: (entityId: string) => void;
 		onRemoveResource: (id: number) => void;
 		onRemovePlayer: (entityId: string) => void;
-		onColorChangeResource: (id: number, color: string) => void;
-		onColorChangePlayer: (entityId: string, color: string) => void;
 	} = $props();
 
 	const tracking = getTrackingState();
@@ -47,10 +43,8 @@
 				onColorChange={(color) => {
 					if (item.type === 'player' && item.entityId) {
 						updateTrackingItemColorByEntityId(item.entityId, color);
-						onColorChangePlayer(item.entityId, color);
 					} else {
 						updateTrackingItemColor(item.id, color);
-						onColorChangeResource(item.id, color);
 					}
 				}}
 			/>

--- a/src/lib/stores/tracking-store.svelte.ts
+++ b/src/lib/stores/tracking-store.svelte.ts
@@ -1,6 +1,7 @@
 import type { TrackingItem } from '$lib/types/geojson';
 
 const STORAGE_KEY = 'trackingColors';
+const NAMES_KEY = 'trackingNames';
 let cachedStore: Record<string, string> | null = null;
 
 if (typeof window !== 'undefined') {
@@ -72,8 +73,41 @@ export function getAllColorPreferences(): Record<string, string> {
 export function clearAllColorPreferences(): void {
 	try {
 		localStorage.removeItem(STORAGE_KEY);
+		localStorage.removeItem(NAMES_KEY);
 	} catch (e) { console.warn('Failed to clear color preferences:', e); }
 	cachedStore = null;
+}
+
+function getNameStore(): Record<string, string> {
+	try {
+		return JSON.parse(localStorage.getItem(NAMES_KEY) || '{}');
+	} catch {
+		return {};
+	}
+}
+
+export function saveDisplayName(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string, name: string): void {
+	const store = getNameStore();
+	store[colorKey(type, id)] = name;
+	try {
+		localStorage.setItem(NAMES_KEY, JSON.stringify(store));
+	} catch { /* ignore */ }
+}
+
+export function loadDisplayName(type: 'resource' | 'enemy' | 'player' | undefined, id: number | string): string | undefined {
+	return getNameStore()[colorKey(type, id)];
+}
+
+export function getAllDisplayNames(): Record<string, string> {
+	return getNameStore();
+}
+
+type ColorSyncHandler = (type: 'resource' | 'enemy' | 'player', id: number | string, color: string) => void;
+let colorSyncHandler: ColorSyncHandler | null = null;
+
+export function registerColorSyncHandler(handler: ColorSyncHandler): () => void {
+	colorSyncHandler = handler;
+	return () => { colorSyncHandler = null; };
 }
 
 let items = $state<TrackingItem[]>([]);
@@ -88,10 +122,12 @@ export function addTrackingItem(item: TrackingItem): void {
 	if (item.type === 'player' && item.entityId) {
 		if (!items.some((i) => i.entityId === item.entityId)) {
 			items = [...items, item];
+			saveDisplayName(item.type, item.entityId, item.text);
 		}
 	} else {
 		if (!items.some((i) => i.id === item.id)) {
 			items = [...items, item];
+			if (item.type) saveDisplayName(item.type, item.id, item.text);
 		}
 	}
 }
@@ -117,12 +153,14 @@ export function updateTrackingItemColor(id: number, color: string): void {
 	const item = items.find((i) => i.id === id);
 	if (item) saveColorPreference(item.type, id, color);
 	items = items.map((i) => (i.id === id ? { ...i, color } : i));
+	if (item?.type) colorSyncHandler?.(item.type, id, color);
 }
 
 export function updateTrackingItemColorByEntityId(entityId: string, color: string): void {
 	if (!isValidColor(color)) return;
 	saveColorPreference('player', entityId, color);
 	items = items.map((i) => (i.entityId === entityId ? { ...i, color } : i));
+	colorSyncHandler?.('player', entityId, color);
 }
 
 export function clearTracking(): void {


### PR DESCRIPTION
- Replaced prop-drilled onColorChangeResource/onColorChangePlayer handlers with a registerColorSyncHandler pattern in the tracking store, so color changes from any component automatically sync map markers/layers
- Added saveDisplayName/loadDisplayName to persist custom player/resource names in localStorage
- Simplified SettingsPanel color picker HTML structure